### PR TITLE
feat: Switch to OpenAI Realtime API for voice calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# ClawdTalk Configuration
+
+# Telnyx API Key (required for phone calls)
+TELNYX_API_KEY=your_telnyx_api_key
+
+# OpenAI API Key (required for Realtime voice)
+OPENAI_API_KEY=your_openai_api_key
+
+# Voice settings (optional)
+OPENAI_VOICE=alloy
+
+# Server settings (optional)
+PORT=3000
+HOSTNAME=localhost
+
+# LLM fallback for SMS (optional)
+ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/README.md
+++ b/README.md
@@ -1,36 +1,94 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ClawdTalk
 
-## Getting Started
+Multi-channel AI agent platform with real-time voice powered by OpenAI Realtime API.
 
-First, run the development server:
+## Features
+
+- 📞 **Voice Calls** - Natural, low-latency conversations with OpenAI Realtime
+- 💬 **SMS** - AI-powered text messaging
+- 🎙️ **Real-time Streaming** - Bidirectional audio via Telnyx WebSocket
+- 🔊 **Server-side VAD** - Intelligent turn detection
+
+## Architecture
+
+```
+Phone Call → Telnyx → WebSocket Media Stream → OpenAI Realtime API
+                ↓                                    ↓
+           PCMU Audio ←←←←←←←←←←←←←←←←←←←←←←← AI Response
+```
+
+## Quick Start
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+```
+
+Required keys:
+- `TELNYX_API_KEY` - From [Telnyx Portal](https://portal.telnyx.com)
+- `OPENAI_API_KEY` - From [OpenAI](https://platform.openai.com)
+
+### 3. Start the server
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### 4. Expose with ngrok
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+ngrok http 3000
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+### 5. Configure Telnyx
 
-## Learn More
+1. Go to **Voice → TeXML Applications** in Telnyx Portal
+2. Create a new application
+3. Set webhook URL: `https://your-ngrok-url.ngrok.app/api/webhook/voice`
+4. Assign your phone number
 
-To learn more about Next.js, take a look at the following resources:
+## Voice Configuration
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Available voices (set via `OPENAI_VOICE`):
+- `alloy` (default)
+- `echo`
+- `shimmer`
+- `ash`
+- `ballad`
+- `coral`
+- `sage`
+- `verse`
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Development
 
-## Deploy on Vercel
+```bash
+# Run with hot reload (Next.js only, no WebSocket)
+npm run dev:next
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+# Run with WebSocket support
+npm run dev
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+# Production build
+npm run build
+npm start
+```
+
+## How It Works
+
+1. **Incoming Call**: Telnyx sends webhook to `/api/webhook/voice`
+2. **Answer**: Server answers with streaming configuration
+3. **Media Stream**: Telnyx opens WebSocket to `/media-stream`
+4. **Audio Bridge**: Server connects to OpenAI Realtime API
+5. **Real-time Conversation**: Audio flows bidirectionally with sub-second latency
+
+## License
+
+MIT

--- a/app/api/webhook/voice/route.ts
+++ b/app/api/webhook/voice/route.ts
@@ -1,63 +1,73 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createConversation, addMessage, getConversations } from '@/lib/store';
-import { chatWithLLM } from '@/lib/llm';
+import { createConversation, getConversations } from '@/lib/store';
+
+/**
+ * Voice Webhook Handler for ClawdTalk
+ * 
+ * Uses TeXML <Stream> for real-time OpenAI Realtime integration
+ */
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    console.log('Voice webhook event:', JSON.stringify(body).substring(0, 500));
-    
     const event = body.data?.event_type;
     const callControlId = body.data?.payload?.call_control_id;
     const from = body.data?.payload?.from || 'unknown';
-    const telnyxApiKey = process.env.TELNYX_API_KEY;
+    const to = body.data?.payload?.to || 'unknown';
+    const direction = body.data?.payload?.direction;
 
+    console.log(`[Voice] Event: ${event} | From: ${from} | Direction: ${direction}`);
+
+    const telnyxApiKey = process.env.TELNYX_API_KEY;
     if (!telnyxApiKey) {
-      console.error('TELNYX_API_KEY not set');
+      console.error('[Voice] TELNYX_API_KEY not set');
       return NextResponse.json({ error: 'Telnyx not configured' }, { status: 500 });
     }
 
     const telnyxCmd = async (id: string, command: string, payload: Record<string, unknown> = {}) => {
-      console.log(`Telnyx command: ${command}`, JSON.stringify(payload).substring(0, 200));
+      console.log(`[Telnyx] Command: ${command}`);
       const res = await fetch(`https://api.telnyx.com/v2/calls/${id}/actions/${command}`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${telnyxApiKey}` },
+        headers: { 
+          'Content-Type': 'application/json', 
+          'Authorization': `Bearer ${telnyxApiKey}` 
+        },
         body: JSON.stringify(payload),
       });
       const text = await res.text();
-      console.log(`Telnyx response (${res.status}):`, text.substring(0, 300));
+      if (!res.ok) {
+        console.error(`[Telnyx] Error ${res.status}: ${text}`);
+      }
       return { status: res.status, body: text };
     };
 
     switch (event) {
       case 'call.initiated': {
-        console.log('Call initiated, answering...');
-        const direction = body.data?.payload?.direction;
+        console.log('[Voice] Call initiated');
         if (direction === 'incoming') {
+          // Answer with streaming enabled
           await telnyxCmd(callControlId, 'answer', {
-            client_state: Buffer.from(JSON.stringify({ step: 'greeting' })).toString('base64'),
+            stream_url: `wss://${req.headers.get('host')}/media-stream`,
+            stream_track: 'both_tracks',
+            stream_bidirectional_mode: 'rtp',
+            stream_bidirectional_codec: 'PCMU',
+            client_state: Buffer.from(JSON.stringify({ step: 'streaming' })).toString('base64'),
           });
         }
         break;
       }
 
       case 'call.answered': {
-        console.log('Call answered, speaking greeting...');
-        // Use speak first, then gather speech separately
-        await telnyxCmd(callControlId, 'speak', {
-          payload: 'Hello! Thanks for calling. How can I help you today?',
-          voice: 'female',
-          language: 'en-US',
-          client_state: Buffer.from(JSON.stringify({ step: 'greeting_spoken' })).toString('base64'),
-        });
-
+        console.log('[Voice] Call answered - OpenAI Realtime streaming active');
+        
+        // Create conversation record
         createConversation({
           id: callControlId,
-          agentId: 'default',
-          agentName: 'Voice Agent',
+          agentId: 'openai-realtime',
+          agentName: 'Voice Agent (OpenAI Realtime)',
           channel: 'phone',
           from,
-          messages: [{ id: crypto.randomUUID(), role: 'assistant', content: 'Hello! Thanks for calling. How can I help you today?', timestamp: new Date().toISOString() }],
+          messages: [],
           status: 'active',
           startedAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -65,90 +75,61 @@ export async function POST(req: NextRequest) {
         break;
       }
 
-      case 'call.speak.ended': {
-        console.log('Speak ended, starting speech gather...');
-        // After speaking, start listening for speech
-        await telnyxCmd(callControlId, 'gather', {
-          input: 'speech',
-          language: 'en-US',
-          inter_digit_timeout: 5000,
-          timeout_millis: 15000,
-          minimum_digits: 1,
-          maximum_digits: 128,
-          client_state: Buffer.from(JSON.stringify({ step: 'listening' })).toString('base64'),
-        });
+      case 'streaming.started': {
+        console.log('[Voice] Media streaming started');
         break;
       }
 
-      case 'call.gather.ended': {
-        const speech = body.data?.payload?.speech?.result || body.data?.payload?.digits || '';
-        console.log('Gather ended, speech:', speech);
-        
-        if (speech) {
-          addMessage(callControlId, {
-            id: crypto.randomUUID(), role: 'user', content: speech, timestamp: new Date().toISOString(),
-          });
-
-          try {
-            // Build conversation history
-            const conv = getConversations().find(c => c.id === callControlId);
-            const messages = conv ? conv.messages.map(m => ({ role: m.role, content: m.content })) : [];
-            messages.push({ role: 'user', content: speech });
-
-            const reply = await chatWithLLM({
-              provider: 'anthropic', model: 'claude-sonnet-4-20250514',
-              messages: [
-                { role: 'system', content: 'You are a helpful phone agent for Assistable AI. Keep responses brief, conversational, and natural-sounding. Limit responses to 2-3 sentences.' },
-                ...messages,
-              ],
-              apiKey: process.env.ANTHROPIC_API_KEY || '',
-            });
-
-            addMessage(callControlId, {
-              id: crypto.randomUUID(), role: 'assistant', content: reply, timestamp: new Date().toISOString(),
-            });
-
-            // Speak the reply, then gather will restart via call.speak.ended
-            await telnyxCmd(callControlId, 'speak', {
-              payload: reply,
-              voice: 'female',
-              language: 'en-US',
-              client_state: Buffer.from(JSON.stringify({ step: 'reply_spoken' })).toString('base64'),
-            });
-          } catch (err) {
-            console.error('LLM error:', err);
-            await telnyxCmd(callControlId, 'speak', {
-              payload: 'I apologize, I encountered an error. Could you repeat that?',
-              voice: 'female',
-              language: 'en-US',
-            });
-          }
-        } else {
-          // No speech detected, ask again
-          await telnyxCmd(callControlId, 'speak', {
-            payload: "I didn't catch that. Could you say that again?",
-            voice: 'female',
-            language: 'en-US',
-          });
-        }
+      case 'streaming.stopped': {
+        console.log('[Voice] Media streaming stopped');
         break;
       }
 
       case 'call.hangup': {
-        console.log('Call hung up');
+        console.log('[Voice] Call ended');
         const convs = getConversations();
         const conv = convs.find(c => c.id === callControlId);
-        if (conv) conv.status = 'ended';
+        if (conv) {
+          conv.status = 'ended';
+          conv.updatedAt = new Date().toISOString();
+        }
         break;
       }
 
       default:
-        console.log('Unhandled event:', event);
+        if (event) {
+          console.log(`[Voice] Unhandled event: ${event}`);
+        }
     }
 
     return NextResponse.json({ status: 'ok' });
   } catch (err) {
-    console.error('Webhook error:', err);
+    console.error('[Voice] Webhook error:', err);
     return NextResponse.json({ status: 'ok' });
   }
+}
+
+/**
+ * TeXML handler for incoming calls
+ * Returns TeXML response to start streaming
+ */
+export async function GET(req: NextRequest) {
+  const host = req.headers.get('host') || 'localhost:3000';
+  
+  // TeXML response with streaming
+  const texmlResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say voice="Polly.Joanna">Please wait while we connect you to the AI assistant.</Say>
+  <Pause length="1"/>
+  <Connect>
+    <Stream url="wss://${host}/media-stream" bidirectionalMode="rtp" codec="PCMU" />
+  </Connect>
+</Response>`;
+
+  return new NextResponse(texmlResponse, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/xml',
+    },
+  });
 }

--- a/lib/realtime/openai-bridge.ts
+++ b/lib/realtime/openai-bridge.ts
@@ -1,0 +1,218 @@
+/**
+ * OpenAI Realtime Bridge for ClawdTalk
+ * 
+ * Bridges Telnyx WebSocket media streaming ↔ OpenAI Realtime API
+ * for natural, low-latency voice conversations.
+ */
+
+import WebSocket from 'ws';
+
+const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01';
+
+interface BridgeConfig {
+  openaiApiKey: string;
+  voice?: string;
+  systemPrompt?: string;
+  onTranscript?: (text: string, role: 'user' | 'assistant') => void;
+  onError?: (error: Error) => void;
+}
+
+interface TelnyxMediaEvent {
+  event: string;
+  stream_id?: string;
+  sequence_number?: string;
+  media?: {
+    track?: string;
+    chunk?: string;
+    timestamp?: string;
+    payload?: string;
+  };
+  start?: {
+    call_control_id?: string;
+    from?: string;
+    to?: string;
+    media_format?: {
+      encoding?: string;
+      sample_rate?: number;
+      channels?: number;
+    };
+  };
+}
+
+export class OpenAIRealtimeBridge {
+  private openaiWs: WebSocket | null = null;
+  private config: BridgeConfig;
+  private streamId: string | null = null;
+  private isConnected = false;
+
+  constructor(config: BridgeConfig) {
+    this.config = {
+      voice: 'alloy',
+      systemPrompt: `You are a helpful AI voice assistant. Keep responses brief and conversational.
+- Speak naturally, as if on a phone call
+- Limit responses to 2-3 sentences unless asked for more detail
+- Don't use markdown, bullets, or formatting
+- Say numbers naturally (e.g., "fifteen hundred" not "1,500")
+- You have access to the caller's context and tools when needed`,
+      ...config,
+    };
+  }
+
+  /**
+   * Connect to OpenAI Realtime API
+   */
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.openaiWs = new WebSocket(OPENAI_REALTIME_URL, {
+        headers: {
+          Authorization: `Bearer ${this.config.openaiApiKey}`,
+          'OpenAI-Beta': 'realtime=v1',
+        },
+      });
+
+      this.openaiWs.on('open', () => {
+        console.log('[OpenAI] Connected to Realtime API');
+        this.isConnected = true;
+        
+        // Configure session
+        setTimeout(() => {
+          this.sendSessionUpdate();
+          resolve();
+        }, 100);
+      });
+
+      this.openaiWs.on('error', (error) => {
+        console.error('[OpenAI] WebSocket error:', error);
+        this.config.onError?.(error as Error);
+        reject(error);
+      });
+
+      this.openaiWs.on('close', () => {
+        console.log('[OpenAI] Disconnected from Realtime API');
+        this.isConnected = false;
+      });
+    });
+  }
+
+  /**
+   * Send session configuration to OpenAI
+   */
+  private sendSessionUpdate(): void {
+    if (!this.openaiWs || this.openaiWs.readyState !== WebSocket.OPEN) return;
+
+    const sessionUpdate = {
+      type: 'session.update',
+      session: {
+        turn_detection: { type: 'server_vad' },
+        input_audio_format: 'g711_ulaw',
+        output_audio_format: 'g711_ulaw',
+        voice: this.config.voice,
+        instructions: this.config.systemPrompt,
+        modalities: ['text', 'audio'],
+        temperature: 0.8,
+      },
+    };
+
+    console.log('[OpenAI] Sending session update');
+    this.openaiWs.send(JSON.stringify(sessionUpdate));
+  }
+
+  /**
+   * Handle incoming Telnyx media event
+   */
+  handleTelnyxEvent(event: TelnyxMediaEvent): string | null {
+    switch (event.event) {
+      case 'start':
+        this.streamId = event.stream_id || null;
+        console.log('[Telnyx] Stream started:', this.streamId);
+        break;
+
+      case 'media':
+        if (event.media?.payload && this.isConnected && this.openaiWs?.readyState === WebSocket.OPEN) {
+          // Forward audio to OpenAI
+          this.openaiWs.send(JSON.stringify({
+            type: 'input_audio_buffer.append',
+            audio: event.media.payload,
+          }));
+        }
+        break;
+
+      case 'stop':
+        console.log('[Telnyx] Stream stopped');
+        this.close();
+        break;
+
+      default:
+        console.log('[Telnyx] Event:', event.event);
+    }
+
+    return null;
+  }
+
+  /**
+   * Set up handler for OpenAI responses to send back to Telnyx
+   */
+  onAudioResponse(callback: (audioBase64: string) => void): void {
+    if (!this.openaiWs) return;
+
+    this.openaiWs.on('message', (data: WebSocket.Data) => {
+      try {
+        const response = JSON.parse(data.toString());
+
+        // Log important events
+        if (['session.created', 'session.updated', 'response.done', 
+             'input_audio_buffer.speech_started', 'input_audio_buffer.speech_stopped'].includes(response.type)) {
+          console.log('[OpenAI] Event:', response.type);
+        }
+
+        // Forward audio deltas to Telnyx
+        if (response.type === 'response.audio.delta' && response.delta) {
+          callback(response.delta);
+        }
+
+        // Handle transcripts for logging
+        if (response.type === 'conversation.item.input_audio_transcription.completed') {
+          this.config.onTranscript?.(response.transcript || '', 'user');
+        }
+
+        if (response.type === 'response.audio_transcript.done') {
+          this.config.onTranscript?.(response.transcript || '', 'assistant');
+        }
+
+      } catch (error) {
+        console.error('[OpenAI] Error parsing message:', error);
+      }
+    });
+  }
+
+  /**
+   * Interrupt current response (for barge-in)
+   */
+  interrupt(): void {
+    if (!this.openaiWs || this.openaiWs.readyState !== WebSocket.OPEN) return;
+
+    // Clear OpenAI's response
+    this.openaiWs.send(JSON.stringify({
+      type: 'response.cancel',
+    }));
+  }
+
+  /**
+   * Close the bridge
+   */
+  close(): void {
+    if (this.openaiWs) {
+      if (this.openaiWs.readyState === WebSocket.OPEN) {
+        this.openaiWs.close();
+      }
+      this.openaiWs = null;
+    }
+    this.isConnected = false;
+  }
+
+  get connected(): boolean {
+    return this.isConnected;
+  }
+}
+
+export default OpenAIRealtimeBridge;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "clawdtalk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawdtalk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "next": "14.2.35",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "ws": "^8.16.0"
       },
       "devDependencies": {
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/ws": "^8",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -313,6 +315,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/any-promise": {
@@ -1461,6 +1473,27 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,26 @@
 {
   "name": "clawdtalk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
+    "dev:next": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=production node server.js",
     "lint": "next lint"
   },
   "dependencies": {
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.2.35"
+    "next": "14.2.35",
+    "ws": "^8.16.0"
   },
   "devDependencies": {
     "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/ws": "^8",
     "postcss": "^8",
     "tailwindcss": "^3.4.1"
   }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,240 @@
+/**
+ * ClawdTalk Custom Server
+ * 
+ * Provides Next.js + WebSocket support for OpenAI Realtime integration
+ */
+
+const { createServer } = require('http');
+const { parse } = require('url');
+const next = require('next');
+const { WebSocketServer, WebSocket } = require('ws');
+
+const dev = process.env.NODE_ENV !== 'production';
+const hostname = process.env.HOSTNAME || 'localhost';
+const port = parseInt(process.env.PORT || '3000', 10);
+
+// OpenAI Realtime configuration
+const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01';
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+const SYSTEM_PROMPT = `You are a helpful AI voice assistant for ClawdTalk.
+
+VOICE RULES:
+- Keep responses SHORT (1-3 sentences). This is a phone call.
+- Speak naturally. NO markdown, NO bullet points, NO asterisks.
+- Be direct and conversational.
+- Numbers: say naturally ("fifteen hundred" not "1,500").
+- Don't repeat back what the caller said.
+
+You are friendly, helpful, and efficient. Get to the point quickly.`;
+
+const VOICE = process.env.OPENAI_VOICE || 'alloy';
+
+// Track active calls
+const activeCalls = new Map();
+
+const app = next({ dev, hostname, port });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  const server = createServer(async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url, true);
+      await handle(req, res, parsedUrl);
+    } catch (err) {
+      console.error('Error handling request:', err);
+      res.statusCode = 500;
+      res.end('Internal Server Error');
+    }
+  });
+
+  // WebSocket server for media streaming
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (request, socket, head) => {
+    const { pathname } = parse(request.url, true);
+
+    if (pathname === '/media-stream') {
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        wss.emit('connection', ws, request);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+
+  // Handle WebSocket connections from Telnyx
+  wss.on('connection', (telnyxWs, request) => {
+    console.log('[ClawdTalk] New media stream connection');
+    
+    let openaiWs = null;
+    let streamId = null;
+    let callControlId = null;
+
+    // Connect to OpenAI Realtime
+    const connectToOpenAI = () => {
+      if (!OPENAI_API_KEY) {
+        console.error('[ClawdTalk] OPENAI_API_KEY not set!');
+        return;
+      }
+
+      openaiWs = new WebSocket(OPENAI_REALTIME_URL, {
+        headers: {
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+          'OpenAI-Beta': 'realtime=v1',
+        },
+      });
+
+      openaiWs.on('open', () => {
+        console.log('[OpenAI] Connected to Realtime API');
+        
+        // Configure session after connection
+        setTimeout(() => {
+          const sessionUpdate = {
+            type: 'session.update',
+            session: {
+              turn_detection: { type: 'server_vad' },
+              input_audio_format: 'g711_ulaw',
+              output_audio_format: 'g711_ulaw',
+              voice: VOICE,
+              instructions: SYSTEM_PROMPT,
+              modalities: ['text', 'audio'],
+              temperature: 0.8,
+            },
+          };
+          openaiWs.send(JSON.stringify(sessionUpdate));
+          console.log('[OpenAI] Session configured');
+        }, 100);
+      });
+
+      openaiWs.on('message', (data) => {
+        try {
+          const response = JSON.parse(data.toString());
+
+          // Log significant events
+          const logEvents = [
+            'session.created', 'session.updated', 'response.done',
+            'input_audio_buffer.speech_started', 'input_audio_buffer.speech_stopped',
+            'error'
+          ];
+          
+          if (logEvents.includes(response.type)) {
+            console.log(`[OpenAI] ${response.type}`, response.type === 'error' ? response.error : '');
+          }
+
+          // Forward audio to Telnyx
+          if (response.type === 'response.audio.delta' && response.delta) {
+            if (telnyxWs.readyState === WebSocket.OPEN) {
+              telnyxWs.send(JSON.stringify({
+                event: 'media',
+                media: {
+                  payload: response.delta,
+                },
+              }));
+            }
+          }
+
+          // Log transcripts
+          if (response.type === 'conversation.item.input_audio_transcription.completed') {
+            console.log(`[Transcript] User: ${response.transcript}`);
+          }
+          if (response.type === 'response.audio_transcript.done') {
+            console.log(`[Transcript] AI: ${response.transcript}`);
+          }
+
+        } catch (error) {
+          console.error('[OpenAI] Parse error:', error);
+        }
+      });
+
+      openaiWs.on('error', (error) => {
+        console.error('[OpenAI] WebSocket error:', error.message);
+      });
+
+      openaiWs.on('close', () => {
+        console.log('[OpenAI] Disconnected');
+      });
+    };
+
+    // Handle messages from Telnyx
+    telnyxWs.on('message', (message) => {
+      try {
+        const data = JSON.parse(message.toString());
+
+        switch (data.event) {
+          case 'connected':
+            console.log('[Telnyx] WebSocket connected');
+            break;
+
+          case 'start':
+            streamId = data.stream_id;
+            callControlId = data.start?.call_control_id;
+            console.log(`[Telnyx] Stream started: ${streamId}`);
+            console.log(`[Telnyx] From: ${data.start?.from} To: ${data.start?.to}`);
+            console.log(`[Telnyx] Format: ${JSON.stringify(data.start?.media_format)}`);
+            
+            // Connect to OpenAI when stream starts
+            connectToOpenAI();
+            
+            // Track active call
+            if (callControlId) {
+              activeCalls.set(callControlId, {
+                streamId,
+                startTime: Date.now(),
+                from: data.start?.from,
+                to: data.start?.to,
+              });
+            }
+            break;
+
+          case 'media':
+            // Forward audio to OpenAI
+            if (openaiWs && openaiWs.readyState === WebSocket.OPEN && data.media?.payload) {
+              openaiWs.send(JSON.stringify({
+                type: 'input_audio_buffer.append',
+                audio: data.media.payload,
+              }));
+            }
+            break;
+
+          case 'stop':
+            console.log('[Telnyx] Stream stopped');
+            if (callControlId) {
+              activeCalls.delete(callControlId);
+            }
+            break;
+
+          case 'dtmf':
+            console.log(`[Telnyx] DTMF: ${data.dtmf?.digit}`);
+            break;
+
+          default:
+            console.log(`[Telnyx] Event: ${data.event}`);
+        }
+      } catch (error) {
+        console.error('[Telnyx] Parse error:', error);
+      }
+    });
+
+    telnyxWs.on('close', () => {
+      console.log('[Telnyx] Client disconnected');
+      if (openaiWs && openaiWs.readyState === WebSocket.OPEN) {
+        openaiWs.close();
+      }
+      if (callControlId) {
+        activeCalls.delete(callControlId);
+      }
+    });
+
+    telnyxWs.on('error', (error) => {
+      console.error('[Telnyx] WebSocket error:', error.message);
+    });
+  });
+
+  server.listen(port, (err) => {
+    if (err) throw err;
+    console.log(`> ClawdTalk ready on http://${hostname}:${port}`);
+    console.log(`> OpenAI Realtime voice enabled: ${OPENAI_API_KEY ? 'YES' : 'NO (missing API key)'}`);
+    console.log(`> Voice: ${VOICE}`);
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the turn-based speak/gather flow with real-time bidirectional audio streaming via OpenAI's Realtime API.

## Why
The previous Hume EVI integration was experiencing reliability issues (~7 second error). OpenAI Realtime provides:
- Lower latency (sub-second)
- More reliable connection
- Server-side VAD
- Better voice quality

## Architecture
```
Phone → Telnyx → WebSocket Media Stream → OpenAI Realtime API
           ↓                                    ↓
       PCMU Audio ←←←←←←←←←←←←←←←←←←←←←←← AI Response
```

## Changes
- Add `server.js` with WebSocket + Next.js support
- Update voice webhook to use Telnyx streaming answer
- Add `OpenAIRealtimeBridge` helper class
- Update `package.json` with `ws` dependency
- Add `.env.example` with required config

## Testing
- Server starts successfully with `npm run dev`
- WebSocket endpoint available at `/media-stream`
- Verified syntax and module loading

## Required Environment Variables
- `TELNYX_API_KEY`
- `OPENAI_API_KEY`
- `OPENAI_VOICE` (optional, defaults to 'alloy')